### PR TITLE
Normalize GitHub repo URLs to always end in .git with .ScrubNuspecRepositoryUrl

### DIFF
--- a/Tests/Verify.Nupkg.Tests/NupkgPluginTests.BasicTest/manifest.verified.nuspec
+++ b/Tests/Verify.Nupkg.Tests/NupkgPluginTests.BasicTest/manifest.verified.nuspec
@@ -6,7 +6,7 @@
     <authors>SamplePackage</authors>
     <readme>README.md</readme>
     <description>Package Description</description>
-    <repository type="git" url="https://github.com/MattKotsenas/Verify.Nupkg" commit="****************************************" />
+    <repository type="git" url="https://github.com/MattKotsenas/Verify.Nupkg.git" commit="****************************************" />
     <dependencies>
       <group targetFramework="net8.0" />
     </dependencies>

--- a/Tests/Verify.Nupkg.Tests/NupkgPluginTests.CustomFileExclusionTest/manifest.verified.nuspec
+++ b/Tests/Verify.Nupkg.Tests/NupkgPluginTests.CustomFileExclusionTest/manifest.verified.nuspec
@@ -6,7 +6,7 @@
     <authors>SamplePackage</authors>
     <readme>README.md</readme>
     <description>Package Description</description>
-    <repository type="git" url="https://github.com/MattKotsenas/Verify.Nupkg" commit="****************************************" />
+    <repository type="git" url="https://github.com/MattKotsenas/Verify.Nupkg.git" commit="****************************************" />
     <dependencies>
       <group targetFramework="net8.0" />
     </dependencies>

--- a/Tests/Verify.Nupkg.Tests/NuspecScrubberTests.cs
+++ b/Tests/Verify.Nupkg.Tests/NuspecScrubberTests.cs
@@ -1,0 +1,23 @@
+﻿using FluentAssertions;
+
+namespace Verify.Nupkg.Tests
+{
+    public class NuspecScrubberTests
+    {
+        [Theory]
+        [InlineData("    <repository type=\"git\" url=\"https://github.com/MattKotsenas/Verify.Nupkg.git\" commit=\"3143135c18bb9bc04b35550ea77189e806738d46\" />", "    <repository type=\"git\" url=\"https://github.com/MattKotsenas/Verify.Nupkg.git\" commit=\"3143135c18bb9bc04b35550ea77189e806738d46\" />")]
+        [InlineData("    <repository type=\"git\" url=\"https://github.com/MattKotsenas/Verify.Nupkg\" commit=\"3143135c18bb9bc04b35550ea77189e806738d46\" />", "    <repository type=\"git\" url=\"https://github.com/MattKotsenas/Verify.Nupkg.git\" commit=\"3143135c18bb9bc04b35550ea77189e806738d46\" />")]
+        [InlineData("    <repository type=\"git\" url=\"file://github.com/MattKotsenas/Verify.Nupkg\" commit=\"3143135c18bb9bc04b35550ea77189e806738d46\" />", "    <repository type=\"git\" url=\"file://github.com/MattKotsenas/Verify.Nupkg\" commit=\"3143135c18bb9bc04b35550ea77189e806738d46\" />")]
+        [InlineData("a string that isn't valid XML", "a string that isn't valid XML")]
+        [InlineData("    <repository type=\"git\" url=\"https://bitbucket.org/the_best/awesome_repo\" commit=\"3143135c18bb9bc04b35550ea77189e806738d46\" />", "    <repository type=\"git\" url=\"https://bitbucket.org/the_best/awesome_repo\" commit=\"3143135c18bb9bc04b35550ea77189e806738d46\" />")]
+        [InlineData("    <id>SamplePackage</id>", "    <id>SamplePackage</id>")]
+        public void ScrubRepositoryUrlNormalizesDotGitForGitHubUrls(string line, string expected)
+        {
+            var scrubber = new NuspecScrubber();
+
+            string actual = scrubber.ScrubRepositoryUrl(line);
+
+            actual.Should().Be(expected);
+        }
+    }
+}

--- a/Tests/Verify.Nupkg.Tests/ProjectTests.Baseline/manifest.verified.nuspec
+++ b/Tests/Verify.Nupkg.Tests/ProjectTests.Baseline/manifest.verified.nuspec
@@ -12,7 +12,7 @@
     <description>Extends Verify (https://github.com/VerifyTests/Verify) to allow verification of NuGet .nupkg files.</description>
     <copyright>Copyright 2024. All rights reserved</copyright>
     <tags>NuGet, Nupkg, Verify</tags>
-    <repository type="git" url="https://github.com/MattKotsenas/Verify.Nupkg" commit="****************************************" />
+    <repository type="git" url="https://github.com/MattKotsenas/Verify.Nupkg.git" commit="****************************************" />
     <dependencies>
       <group targetFramework=".NETFramework4.7.2">
         <dependency id="Spectre.Console.Testing" version="0.48.0" exclude="Build,Analyzers" />

--- a/Tests/Verify.Nupkg.Tests/Verify.Nupkg.Tests.csproj
+++ b/Tests/Verify.Nupkg.Tests/Verify.Nupkg.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
-    <PackageReference Include="Polyfill" Version="2.1.0" PrivateAssets="all" />
     <PackageReference Include="Verify.Xunit" Version="23.0.1" />
     <PackageReference Include="xunit" Version="2.6.6" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" PrivateAssets="all" />

--- a/Verify.Nupkg/StringExtensions.cs
+++ b/Verify.Nupkg/StringExtensions.cs
@@ -1,0 +1,26 @@
+﻿using System.Text;
+
+namespace Verify.Nupkg;
+
+internal static class StringExtensions
+{
+    public static string GetLeadingWhiteSpace(this string text)
+    {
+        StringBuilder sb = new();
+
+        for (int i = 0; i < text.Length; i++)
+        {
+            char c = text[i];
+            if (char.IsWhiteSpace(c))
+            {
+                sb.Append(c);
+            }
+            else
+            {
+                break;
+            }
+        }
+
+        return sb.ToString();
+    }
+}

--- a/Verify.Nupkg/Verify.Nupkg.csproj
+++ b/Verify.Nupkg/Verify.Nupkg.csproj
@@ -10,7 +10,6 @@
     <Description>Extends Verify (https://github.com/VerifyTests/Verify) to allow verification of NuGet .nupkg files.</Description>
     <Copyright>Copyright 2024. All rights reserved</Copyright>
     <PackageProjectUrl>https://github.com/MattKotsenas/Verify.Nupkg</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/MattKotsenas/Verify.Nupkg</RepositoryUrl>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>

--- a/Verify.Nupkg/VerifyNupkg.cs
+++ b/Verify.Nupkg/VerifyNupkg.cs
@@ -1,5 +1,8 @@
 ﻿using System.IO.Compression;
+using System.Runtime.CompilerServices;
 using Verify.Nupkg;
+
+[assembly: InternalsVisibleTo("Verify.Nupkg.Tests")]
 
 namespace VerifyTests;
 

--- a/Verify.Nupkg/VerifySettingsScrubExtensions.cs
+++ b/Verify.Nupkg/VerifySettingsScrubExtensions.cs
@@ -22,19 +22,21 @@ public static class VerifySettingsScrubExtensions
     {
         settings.ScrubNuspecVersion();
         settings.ScrubNuspecCommit();
+        settings.ScrubNuspecRepositoryUrl();
     }
 
     /// <summary>
     /// Scrub the nuspec file of common changes.
     /// </summary>
     /// <param name="settings">
-    /// The <see cref="VerifySettings"/> to modify.
+    /// The <see cref="SettingsTask"/> to modify.
     /// </param>
     /// <remarks>
     /// Sources of common changes:
     /// - Package version
     /// - Commit hash
     /// </remarks>
+    /// <returns>The <see cref="SettingsTask"/> for chaining.</returns>
     public static SettingsTask ScrubNuspec(this SettingsTask settings)
     {
         settings.CurrentSettings.ScrubNuspec();
@@ -60,12 +62,13 @@ public static class VerifySettingsScrubExtensions
     /// Scrub the version from the nuspec file.
     /// </summary>
     /// <param name="settings">
-    /// The <see cref="VerifierSettings"/> to modify.
+    /// The <see cref="SettingsTask"/> to modify.
     /// </param>
     /// <remarks>
     /// In some scenarios, package versions are frequent and obvious changes. In these cases, scrub the version
     /// to reduce the noise in the diff.
     /// </remarks>
+    /// <returns>The <see cref="SettingsTask"/> for chaining.</returns>
     public static SettingsTask ScrubNuspecVersion(this SettingsTask settings)
     {
         settings.CurrentSettings.ScrubNuspecVersion();
@@ -91,15 +94,48 @@ public static class VerifySettingsScrubExtensions
     /// Scrub the commit info from the nuspec file.
     /// </summary>
     /// <param name="settings">
-    /// The <see cref="VerifierSettings"/> to modify.
+    /// The <see cref="SettingsTask"/> to modify.
     /// </param>
     /// <remarks>
     /// In some scenarios, the commit used in the package are frequent and obvious changes. In these cases, scrub the commit
     /// to reduce the noise in the diff.
     /// </remarks>
+    /// <returns>The <see cref="SettingsTask"/> for chaining.</returns>
     public static SettingsTask ScrubNuspecCommit(this SettingsTask settings)
     {
          settings.CurrentSettings.ScrubNuspecCommit();
          return settings;
+    }
+
+    /// <summary>
+    /// Scrub and normalize the repository URL in the nuspec file.
+    /// </summary>
+    /// <param name="settings">
+    /// The <see cref="VerifierSettings"/> to modify.
+    /// </param>
+    /// <remarks>
+    /// GitHub repository URLs can be optionally have a `.git` suffix. This method normalizes the URL to always end with .git
+    /// to reduce the noise in the diff.
+    /// </remarks>
+    public static void ScrubNuspecRepositoryUrl(this VerifySettings settings)
+    {
+        settings.ScrubLinesWithReplace(extension: "nuspec", line => _scrubber.ScrubRepositoryUrl(line));
+    }
+
+    /// <summary>
+    /// Scrub and normalize the repository URL in the nuspec file.
+    /// </summary>
+    /// <param name="settings">
+    /// The <see cref="SettingsTask"/> to modify.
+    /// </param>
+    /// <remarks>
+    /// GitHub repository URLs can be optionally have a `.git` suffix. This method normalizes the URL to always end with .git
+    /// to reduce the noise in the diff.
+    /// </remarks>
+    /// <returns>The <see cref="SettingsTask"/> for chaining.</returns>
+    public static SettingsTask ScrubNuspecRepositoryUrl(this SettingsTask settings)
+    {
+        settings.CurrentSettings.ScrubNuspecRepositoryUrl();
+        return settings;
     }
 }

--- a/Verify.Nupkg/XElementExtensions.cs
+++ b/Verify.Nupkg/XElementExtensions.cs
@@ -1,0 +1,23 @@
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Xml;
+using System.Xml.Linq;
+
+namespace Verify.Nupkg;
+
+internal static class XElementExtensions
+{
+    public static bool TryParseForScrubbing(string text, [NotNullWhen(true)] out XElement? element, LoadOptions options = LoadOptions.PreserveWhitespace)
+    {
+        try
+        {
+            element = XElement.Parse(text, options);
+            return true;
+        }
+        catch (XmlException)
+        {
+            element = null;
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
GitHub clone URLs have an optional `.git` at the end depending on how the repo is cloned. Both URL formats work both in the git client and in browsers.

In order to reduce diff noise / churn, add a new scrubber: `ScrubNuSpecRepositoryUrl` and add it to the default scrubbers.