### PR TITLE
Add benchmark for Nuspec scrubbing

### DIFF
--- a/Verify.Nupkg.sln
+++ b/Verify.Nupkg.sln
@@ -14,6 +14,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Verify.Nupkg.Tests", "Tests\Verify.Nupkg.Tests\Verify.Nupkg.Tests.csproj", "{FD87C543-2D04-4338-8509-0CF543BC8F98}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Benchmarks", "benchmarks\Benchmarks.csproj", "{AFF48013-5364-4C3A-9F1B-FFF38CD77F1A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -28,6 +30,10 @@ Global
 		{FD87C543-2D04-4338-8509-0CF543BC8F98}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FD87C543-2D04-4338-8509-0CF543BC8F98}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FD87C543-2D04-4338-8509-0CF543BC8F98}.Release|Any CPU.Build.0 = Release|Any CPU
+		{AFF48013-5364-4C3A-9F1B-FFF38CD77F1A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AFF48013-5364-4C3A-9F1B-FFF38CD77F1A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AFF48013-5364-4C3A-9F1B-FFF38CD77F1A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AFF48013-5364-4C3A-9F1B-FFF38CD77F1A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/benchmarks/Benchmarks.csproj
+++ b/benchmarks/Benchmarks.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+  </ItemGroup>
+
+</Project>

--- a/benchmarks/Benchmarks.csproj
+++ b/benchmarks/Benchmarks.csproj
@@ -3,12 +3,15 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
-    <ImplicitUsings>enable</ImplicitUsings>
-    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="Verify" Version="23.1.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Verify.Nupkg\Verify.Nupkg.csproj" />
   </ItemGroup>
 
 </Project>

--- a/benchmarks/Program.cs
+++ b/benchmarks/Program.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Security.Cryptography;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Diagnosers;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
+
+namespace Verify.Benchmarks;
+
+public class Md5VsSha256
+{
+    private const int N = 10000;
+    private readonly byte[] data;
+
+    private readonly SHA256 sha256 = SHA256.Create();
+    private readonly MD5 md5 = MD5.Create();
+
+    public Md5VsSha256()
+    {
+        data = new byte[N];
+        new Random(42).NextBytes(data);
+    }
+
+    [Benchmark]
+    public byte[] Sha256() => sha256.ComputeHash(data);
+
+    [Benchmark]
+    public byte[] Md5() => md5.ComputeHash(data);
+}
+
+public class Program
+{
+    public static void Main(string[] args)
+    {
+        var config = DefaultConfig.Instance
+            .AddDiagnoser(MemoryDiagnoser.Default)
+            .AddDiagnoser(ExceptionDiagnoser.Default)
+            .AddJob(Job
+                 .ShortRun
+                 .WithLaunchCount(1)
+                 .WithToolchain(InProcessNoEmitToolchain.Instance)); // Avoid Defender
+
+        var summary = BenchmarkRunner.Run<Md5VsSha256>(config);
+    }
+}

--- a/benchmarks/Program.cs
+++ b/benchmarks/Program.cs
@@ -1,6 +1,4 @@
-﻿using System;
-using System.Security.Cryptography;
-using BenchmarkDotNet.Attributes;
+﻿using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
 using BenchmarkDotNet.Jobs;
@@ -9,39 +7,106 @@ using BenchmarkDotNet.Toolchains.InProcess.NoEmit;
 
 namespace Verify.Benchmarks;
 
-public class Md5VsSha256
+public class NuspecScrubbing
 {
-    private const int N = 10000;
-    private readonly byte[] data;
+    private const string Nuspec =
+@"<?xml version=""1.0"" encoding=""utf-8""?>
+<package xmlns=""http://schemas.microsoft.com/packaging/2013/01/nuspec.xsd"">
+  <metadata minClientVersion=""2.12"">
+    <id>Newtonsoft.Json</id>
+    <version>13.0.3</version>
+    <title>Json.NET</title>
+    <authors>James Newton-King</authors>
+    <owners></owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <license type=""expression"">MIT</license>
+    <icon>packageIcon.png</icon>
+    <readme>README.md</readme>
+    <projectUrl>https://www.newtonsoft.com/json</projectUrl>
+    <iconUrl>https://www.newtonsoft.com/content/images/nugeticon.png</iconUrl>
+    <description>Json.NET is a popular high-performance JSON framework for .NET</description>
+    <copyright>Copyright © James Newton-King 2008</copyright>
+    <tags>json</tags>
+    <repository type=""git"" url=""https://github.com/JamesNK/Newtonsoft.Json"" commit=""0a2e291c0d9c0c7675d445703e51750363a549ef"" />
+    <dependencies>
+      <group targetFramework="".NETFramework2.0"" />
+      <group targetFramework="".NETFramework3.5"" />
+      <group targetFramework="".NETFramework4.0"" />
+      <group targetFramework="".NETFramework4.5"" />
+      <group targetFramework="".NETStandard1.0"">
+        <dependency id=""Microsoft.CSharp"" version=""4.3.0"" exclude=""Build,Analyzers"" />
+        <dependency id=""NETStandard.Library"" version=""1.6.1"" exclude=""Build,Analyzers"" />
+        <dependency id=""System.ComponentModel.TypeConverter"" version=""4.3.0"" exclude=""Build,Analyzers"" />
+        <dependency id=""System.Runtime.Serialization.Primitives"" version=""4.3.0"" exclude=""Build,Analyzers"" />
+      </group>
+      <group targetFramework="".NETStandard1.3"">
+        <dependency id=""Microsoft.CSharp"" version=""4.3.0"" exclude=""Build,Analyzers"" />
+        <dependency id=""NETStandard.Library"" version=""1.6.1"" exclude=""Build,Analyzers"" />
+        <dependency id=""System.ComponentModel.TypeConverter"" version=""4.3.0"" exclude=""Build,Analyzers"" />
+        <dependency id=""System.Runtime.Serialization.Formatters"" version=""4.3.0"" exclude=""Build,Analyzers"" />
+        <dependency id=""System.Runtime.Serialization.Primitives"" version=""4.3.0"" exclude=""Build,Analyzers"" />
+        <dependency id=""System.Xml.XmlDocument"" version=""4.3.0"" exclude=""Build,Analyzers"" />
+      </group>
+      <group targetFramework=""net6.0"" />
+      <group targetFramework="".NETStandard2.0"" />
+    </dependencies>
+  </metadata>
+</package>";
 
-    private readonly SHA256 sha256 = SHA256.Create();
-    private readonly MD5 md5 = MD5.Create();
+    private readonly VerifySettings _settings;
+    private readonly Target _target;
+    private readonly string _verifyFile = Path.Combine(Directory.GetCurrentDirectory(), "can-be-anything.nuspec");
 
-    public Md5VsSha256()
+    public NuspecScrubbing()
     {
-        data = new byte[N];
-        new Random(42).NextBytes(data);
+        _settings = new VerifySettings();
+        _settings.DisableRequireUniquePrefix();
+        _settings.ScrubNuspec();
+        _settings.DisableDiff();
+        _settings.AutoVerify();
+
+        _target = new Target(extension: "nuspec", Nuspec);
     }
 
     [Benchmark]
-    public byte[] Sha256() => sha256.ComputeHash(data);
+    public async Task Baseline()
+    {
+        Func<InnerVerifier, Task<VerifyResult>> verify = _ => _.Verify(_target);
 
-    [Benchmark]
-    public byte[] Md5() => md5.ComputeHash(data);
+        await new SettingsTask(_settings, async verifySettings =>
+        {
+            using var verifier = new InnerVerifier(_verifyFile, verifySettings);
+            return await verify(verifier);
+        });
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        string verifiedFile = _verifyFile.Replace(".nuspec", ".verified.nuspec");
+        File.Delete(verifiedFile);
+    }
 }
 
 public class Program
 {
+    // Use this to debug the harness itself
+    //public static async Task Main()
+    //{
+    //    var benchmark = new NuspecScrubbing();
+    //    await benchmark.Baseline();
+    //    benchmark.Cleanup();
+    //}
+
     public static void Main(string[] args)
     {
         var config = DefaultConfig.Instance
             .AddDiagnoser(MemoryDiagnoser.Default)
             .AddDiagnoser(ExceptionDiagnoser.Default)
             .AddJob(Job
-                 .ShortRun
-                 .WithLaunchCount(1)
+                 .MediumRun
                  .WithToolchain(InProcessNoEmitToolchain.Instance)); // Avoid Defender
 
-        var summary = BenchmarkRunner.Run<Md5VsSha256>(config);
+        var summary = BenchmarkRunner.Run<NuspecScrubbing>(config);
     }
 }


### PR DESCRIPTION
The most performance sensitive part of the extension is nuspec scrubbing. Currently the scrubbers are doing line-by-line scrubbing, which is _just ok_ because the files tend to be small and I don't suspect people are baselining thousands of packages.

I plan to replace the scrubbers with XML-based scrubbing but want to provide a way to verify scrubbing performance doesn't get worse.