### PR TITLE
Add retry to temp directory deletion

### DIFF
--- a/Tests/Verify.Nupkg.Tests/SamplePackages/PackageCreator.cs
+++ b/Tests/Verify.Nupkg.Tests/SamplePackages/PackageCreator.cs
@@ -44,7 +44,7 @@ internal abstract class PackageCreator
     {
         IFileInfo destinationPackage = _fs.FileInfo.New(_fs.Path.Combine(destinationDirectory.FullName, $"{Name}.nupkg"));
 
-        using (_fs.CreateDisposableDirectory(out IDirectoryInfo temp))
+        using (_fs.CreateDisposableDirectory(RetryableTempDirectory.GetRandomTempPath(), dirInfo => new RetryableTempDirectory(dirInfo), out IDirectoryInfo temp))
         {
             using (PackageRepository.Create(temp.FullName, feeds: new Uri("https://api.nuget.org/v3/index.json")))
             {

--- a/Tests/Verify.Nupkg.Tests/SamplePackages/RetryableTempDirectory.cs
+++ b/Tests/Verify.Nupkg.Tests/SamplePackages/RetryableTempDirectory.cs
@@ -14,29 +14,26 @@ internal class RetryableTempDirectory : DisposableDirectory
 
     protected override void Dispose(bool disposing)
     {
-        if (disposing)
+        IOException? lastException = null;
+
+        for (int i = 0; i < 3; i++)
         {
-            IOException? lastException = null;
-
-            for (int i = 0; i < 3; i++)
+            try
             {
-                try
-                {
-                    base.Dispose(disposing);
-                    return;
-                }
-                catch (IOException ex)
-                {
-                    lastException = ex;
-
-                    Thread.Sleep(TimeSpan.FromSeconds(1));
-                }
+                base.Dispose(disposing);
+                return;
             }
-
-            if (lastException is not null)
+            catch (IOException ex)
             {
-                throw new IOException("Failed to delete temp directory after multiple retries.", lastException);
+                lastException = ex;
+
+                Thread.Sleep(TimeSpan.FromSeconds(1));
             }
+        }
+
+        if (lastException is not null)
+        {
+            throw new IOException("Failed to delete temp directory after multiple retries.", lastException);
         }
     }
 

--- a/Tests/Verify.Nupkg.Tests/SamplePackages/RetryableTempDirectory.cs
+++ b/Tests/Verify.Nupkg.Tests/SamplePackages/RetryableTempDirectory.cs
@@ -1,0 +1,51 @@
+﻿using System.IO.Abstractions;
+
+namespace Verify.Nupkg.Tests;
+
+/// <summary>
+/// Helper class that retries deleting a temp directory multiple times. This avoid flakiness when running tests
+/// due to anti-virus or other processes locking the directory.
+/// </summary>
+internal class RetryableTempDirectory : DisposableDirectory
+{
+    public RetryableTempDirectory(IDirectoryInfo directoryInfo) : base(directoryInfo)
+    {
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            IOException? lastException = null;
+
+            for (int i = 0; i < 3; i++)
+            {
+                try
+                {
+                    base.Dispose(disposing);
+                    return;
+                }
+                catch (IOException ex)
+                {
+                    lastException = ex;
+
+                    Thread.Sleep(TimeSpan.FromSeconds(1));
+                }
+            }
+
+            if (lastException is not null)
+            {
+                throw new IOException("Failed to delete temp directory after multiple retries.", lastException);
+            }
+        }
+    }
+
+    // Once https://github.com/TestableIO/System.IO.Abstractions.Extensions/pull/63 lands, remove this method
+    // and use the updated TestableIO.Abstractions.Extensions package instead.
+    internal static string GetRandomTempPath()
+    {
+        var temp = Path.GetTempPath();
+        var fileName = Path.GetRandomFileName();
+        return Path.Combine(temp, fileName);
+    }
+}


### PR DESCRIPTION
Antivirus (I _believe_) is causing occasional flakiness on dev machines where the file handle is being held open after the build completes, which causes an `IOException` when the temporary working directory is deleted.

(Try to) avoid those issues by creating a custom retriable directory deletion `IDisposable`.