### PR TITLE
Reduce diff noise in ASCII tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Here's an example of the diff that results from adding a README to the package:
 +|-- README.md
 |-- SamplePackage.nuspec
 |-- lib
-    |-- net8.0
-        |-- SamplePackage.dll
+|   |-- net8.0
+|   |   |-- SamplePackage.dll
 ```
 
 Verifying package structure is part of an overall solution to prevent accidental package breaks. If you want to verify /
@@ -98,6 +98,11 @@ settings.ScrubNuspec();
 
 which itself is a convenience method for `ScrubNuspecVersion()` and `ScrubNuspecCommit()`. Feel free to use them
 separately if you'd like to verify either of these values.
+
+### ASCII tree
+
+The ASCII art tree is inspired by the `tree` command, but with a few modifications to reduce the amount of
+"noise" that occurs in diffs when files are added / removed.
 
 ## Icon
 

--- a/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.AddGitExtensionToRepoUrl/contents.verified.txt
+++ b/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.AddGitExtensionToRepoUrl/contents.verified.txt
@@ -2,5 +2,5 @@
 |-- README.md
 |-- SimplePackage.nuspec
 |-- lib
-    |-- net8.0
-        |-- SimplePackage.dll
+|   |-- net8.0
+|   |   |-- SimplePackage.dll

--- a/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.DoNotScrubGitExtensionOnRepoUrl/contents.verified.txt
+++ b/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.DoNotScrubGitExtensionOnRepoUrl/contents.verified.txt
@@ -1,5 +1,5 @@
 ﻿/
 |-- PackageWithRepoGitExtension.nuspec
 |-- lib
-    |-- net8.0
-        |-- PackageWithRepoGitExtension.dll
+|   |-- net8.0
+|   |   |-- PackageWithRepoGitExtension.dll

--- a/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.DoNotScrubNonGitHubDomainRepoUrl/contents.verified.txt
+++ b/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.DoNotScrubNonGitHubDomainRepoUrl/contents.verified.txt
@@ -1,5 +1,5 @@
 ﻿/
 |-- PackageWithoutRepoGitHubDomain.nuspec
 |-- lib
-    |-- net8.0
-        |-- PackageWithoutRepoGitHubDomain.dll
+|   |-- net8.0
+|   |   |-- PackageWithoutRepoGitHubDomain.dll

--- a/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.DoNotScrubNonHttpsRepoUrl/contents.verified.txt
+++ b/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.DoNotScrubNonHttpsRepoUrl/contents.verified.txt
@@ -1,5 +1,5 @@
 ﻿/
 |-- PackageWithoutRepoHttps.nuspec
 |-- lib
-    |-- net8.0
-        |-- PackageWithoutRepoHttps.dll
+|   |-- net8.0
+|   |   |-- PackageWithoutRepoHttps.dll

--- a/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.SkipScrubbingForRepoWithNoCommit/contents.verified.txt
+++ b/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.SkipScrubbingForRepoWithNoCommit/contents.verified.txt
@@ -1,5 +1,5 @@
 ﻿/
 |-- PackageWithoutRepoUrlOrCommit.nuspec
 |-- lib
-    |-- net8.0
-        |-- PackageWithoutRepoUrlOrCommit.dll
+|   |-- net8.0
+|   |   |-- PackageWithoutRepoUrlOrCommit.dll

--- a/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.SkipScrubbingForRepoWithNoUrl/contents.verified.txt
+++ b/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.SkipScrubbingForRepoWithNoUrl/contents.verified.txt
@@ -1,5 +1,5 @@
 ﻿/
 |-- PackageWithoutRepoUrlOrCommit.nuspec
 |-- lib
-    |-- net8.0
-        |-- PackageWithoutRepoUrlOrCommit.dll
+|   |-- net8.0
+|   |   |-- PackageWithoutRepoUrlOrCommit.dll

--- a/Tests/Verify.Nupkg.Tests/SimplePackageTests.BasicTest/contents.verified.txt
+++ b/Tests/Verify.Nupkg.Tests/SimplePackageTests.BasicTest/contents.verified.txt
@@ -2,5 +2,5 @@
 |-- README.md
 |-- SimplePackage.nuspec
 |-- lib
-    |-- net8.0
-        |-- SimplePackage.dll
+|   |-- net8.0
+|   |   |-- SimplePackage.dll

--- a/Tests/Verify.Nupkg.Tests/SimplePackageTests.CustomFileExclusionTest/contents.verified.txt
+++ b/Tests/Verify.Nupkg.Tests/SimplePackageTests.CustomFileExclusionTest/contents.verified.txt
@@ -4,5 +4,5 @@
 |-- _rels
 |   |-- .rels
 |-- lib
-    |-- net8.0
-        |-- SimplePackage.dll
+|   |-- net8.0
+|   |   |-- SimplePackage.dll

--- a/Tests/Verify.Nupkg.Tests/SimplePackageTests.OnlyOptInScrubbersRun/contents.verified.txt
+++ b/Tests/Verify.Nupkg.Tests/SimplePackageTests.OnlyOptInScrubbersRun/contents.verified.txt
@@ -2,5 +2,5 @@
 |-- README.md
 |-- SimplePackage.nuspec
 |-- lib
-    |-- net8.0
-        |-- SimplePackage.dll
+|   |-- net8.0
+|   |   |-- SimplePackage.dll

--- a/Tests/Verify.Nupkg.Tests/VerifyNupkgPackageTests.Baseline/contents.verified.txt
+++ b/Tests/Verify.Nupkg.Tests/VerifyNupkgPackageTests.Baseline/contents.verified.txt
@@ -3,15 +3,15 @@
 |-- Verify.Nupkg.nuspec
 |-- icon.png
 |-- lib
-    |-- net472
-    |   |-- Verify.Nupkg.dll
-    |   |-- Verify.Nupkg.xml
-    |-- net6.0
-    |   |-- Verify.Nupkg.dll
-    |   |-- Verify.Nupkg.xml
-    |-- net7.0
-    |   |-- Verify.Nupkg.dll
-    |   |-- Verify.Nupkg.xml
-    |-- net8.0
-        |-- Verify.Nupkg.dll
-        |-- Verify.Nupkg.xml
+|   |-- net472
+|   |   |-- Verify.Nupkg.dll
+|   |   |-- Verify.Nupkg.xml
+|   |-- net6.0
+|   |   |-- Verify.Nupkg.dll
+|   |   |-- Verify.Nupkg.xml
+|   |-- net7.0
+|   |   |-- Verify.Nupkg.dll
+|   |   |-- Verify.Nupkg.xml
+|   |-- net8.0
+|   |   |-- Verify.Nupkg.dll
+|   |   |-- Verify.Nupkg.xml

--- a/Tests/Verify.Nupkg.Tests/VerifyNupkgPackageTests.Baseline/manifest.verified.nuspec
+++ b/Tests/Verify.Nupkg.Tests/VerifyNupkgPackageTests.Baseline/manifest.verified.nuspec
@@ -14,19 +14,15 @@
     <repository type="git" url="https://github.com/MattKotsenas/Verify.Nupkg.git" commit="****************************************" />
     <dependencies>
       <group targetFramework=".NETFramework4.7.2">
-        <dependency id="Spectre.Console.Testing" version="0.48.0" exclude="Build,Analyzers" />
         <dependency id="Verify" version="23.0.1" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net6.0">
-        <dependency id="Spectre.Console.Testing" version="0.48.0" exclude="Build,Analyzers" />
         <dependency id="Verify" version="23.0.1" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net7.0">
-        <dependency id="Spectre.Console.Testing" version="0.48.0" exclude="Build,Analyzers" />
         <dependency id="Verify" version="23.0.1" exclude="Build,Analyzers" />
       </group>
       <group targetFramework="net8.0">
-        <dependency id="Spectre.Console.Testing" version="0.48.0" exclude="Build,Analyzers" />
         <dependency id="Verify" version="23.0.1" exclude="Build,Analyzers" />
       </group>
     </dependencies>

--- a/Verify.Nupkg/PathNode.cs
+++ b/Verify.Nupkg/PathNode.cs
@@ -3,5 +3,5 @@
 internal class PathNode
 {
     public required string Name { get; set; }
-    public List<PathNode> Children { get; set; } = [];
+    public ICollection<PathNode> Children { get; set; } = [];
 }

--- a/Verify.Nupkg/Verify.Nupkg.csproj
+++ b/Verify.Nupkg/Verify.Nupkg.csproj
@@ -14,11 +14,13 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RootNamespace>VerifyTests</RootNamespace>
+
+    <!-- Remove DisableFastUpToDateCheck=true once this is fixed: https://github.com/dotnet/msbuild/issues/9953 -->
+    <DisableFastUpToDateCheck>true</DisableFastUpToDateCheck>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Polyfill" Version="2.1.0" PrivateAssets="all" />
-    <PackageReference Include="Spectre.Console.Testing" Version="0.48.0" />
     <PackageReference Include="Verify" Version="23.0.1" />
   </ItemGroup>
 

--- a/Verify.Nupkg/ZipArchiveExtensions.cs
+++ b/Verify.Nupkg/ZipArchiveExtensions.cs
@@ -1,7 +1,5 @@
-﻿using Spectre.Console;
-using Spectre.Console.Rendering;
-using Spectre.Console.Testing;
-using System.IO.Compression;
+﻿using System.IO.Compression;
+using System.Text;
 using System.Text.RegularExpressions;
 
 namespace VerifyTests;
@@ -40,47 +38,41 @@ internal static class ZipArchiveExtensions
 
         }
 
-        // Spectre.Console requires the top of a tree to be a Tree and not a TreeNode, so start with a dummy TreeNode
-        // and skip the root PathNode
-        TreeNode tn = new(new Markup(""));
-        Walk(tn, [.. root.Children]);
-
-        // Create our Tree root and skip the dummy TreeNode from above
-        Tree tree = new("/")
-        {
-            Guide = new DiffableTreeGuide()
-        };
-        tree.AddNodes(tn.Nodes);
-
-        TestConsole console = new();
-        console.Write(tree);
-
-        return console.Output;
+        return Walk(root);
     }
 
-    private static void Walk(TreeNode treeNode, params PathNode[] pathNodes)
+    private static string Walk(PathNode root)
     {
-        foreach (PathNode pathNode in pathNodes)
+        StringBuilder sb = new();
+
+        Walk(root, 0, sb);
+
+        return sb.ToString();
+    }
+
+    private static void Walk(PathNode node, int depth, StringBuilder sb)
+    {
+        StringBuilder prefix = new();
+
+        if (depth - 1 > 0)
         {
-            TreeNode childTree = treeNode.AddNode(Markup.Escape(pathNode.Name));
-            foreach (PathNode childPath in pathNode.Children.OrderBy(c => c.Name, StringComparer.Ordinal))
+            foreach (var i in Enumerable.Range(0, depth - 1))
             {
-                Walk(childTree, childPath);
+                prefix.Append("|   ");
             }
         }
-    }
 
-    private class DiffableTreeGuide : TreeGuide
-    {
-        public override string GetPart(TreeGuidePart part)
+        if (depth > 0)
         {
-            // Using `End` causes diff noise, so use `Fork` instead
-            if (part == TreeGuidePart.End)
-            {
-                part = TreeGuidePart.Fork;
-            }
+            prefix.Append("|-- ");
+        }
 
-            return Ascii.GetPart(part);
+        sb.Append(prefix);
+        sb.AppendLine(node.Name);
+
+        foreach (PathNode child in node.Children.OrderBy(c => c.Name, StringComparer.Ordinal))
+        {
+            Walk(child, depth + 1, sb);
         }
     }
 }

--- a/Verify.Nupkg/ZipArchiveExtensions.cs
+++ b/Verify.Nupkg/ZipArchiveExtensions.cs
@@ -43,36 +43,38 @@ internal static class ZipArchiveExtensions
 
     private static string Walk(PathNode root)
     {
-        StringBuilder sb = new();
+        StringBuilder output = new();
+        StringBuilder scratch = new();
 
-        Walk(root, 0, sb);
+        Walk(root, 0, output, scratch);
 
-        return sb.ToString();
+        return output.ToString();
     }
 
-    private static void Walk(PathNode node, int depth, StringBuilder sb)
+    // prefixBuilder is a scratch pad for building the prefix. Since this is a simple,
+    // single-threaded operation, we can reuse the same StringBuilder instance without needing
+    // the complexity of an object pool.
+    private static void Walk(PathNode node, int depth, StringBuilder output, StringBuilder prefixBuilder)
     {
-        StringBuilder prefix = new();
-
         if (depth - 1 > 0)
         {
             foreach (var i in Enumerable.Range(0, depth - 1))
             {
-                prefix.Append("|   ");
+                prefixBuilder.Append("|   ");
             }
         }
 
         if (depth > 0)
         {
-            prefix.Append("|-- ");
+            prefixBuilder.Append("|-- ");
         }
 
-        sb.Append(prefix);
-        sb.AppendLine(node.Name);
+        output.Append(prefixBuilder);
+        output.AppendLine(node.Name);
 
         foreach (PathNode child in node.Children.OrderBy(c => c.Name, StringComparer.Ordinal))
         {
-            Walk(child, depth + 1, sb);
+            Walk(child, depth + 1, output, prefixBuilder.Clear());
         }
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0",
+  "version": "1.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/tags/v\\d+\\.\\d+\\.\\d+"


### PR DESCRIPTION
Extend the folder bars down for all files instead of only for files that aren't the last child. This reduces the amount of noise in diffs when files are added / removed, as bars no longer need to be changed.

This change also removes the dependency on Spectre.Console, which was only used for diff rendering.