### PR TITLE
Update to new MSTest source generator

### DIFF
--- a/Tests/Verify.Nupkg.Tests/GlobalUsings.cs
+++ b/Tests/Verify.Nupkg.Tests/GlobalUsings.cs
@@ -1,1 +1,0 @@
-global using Xunit;

--- a/Tests/Verify.Nupkg.Tests/MSTestSettings.cs
+++ b/Tests/Verify.Nupkg.Tests/MSTestSettings.cs
@@ -1,0 +1,1 @@
+﻿[assembly: Parallelize(Scope = ExecutionScope.MethodLevel)]

--- a/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.cs
+++ b/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.cs
@@ -1,6 +1,8 @@
 ﻿namespace Verify.Nupkg.Tests;
 
-public class NuspecScrubbingTests
+[TestClass]
+[UsesVerify]
+public partial class NuspecScrubbingTests
 {
     private string _packageWithRepoGitExtension = SamplePackages.Instance.PackageWithRepoGitExtension.Value.FullName;
     private string _packageWithoutRepoGitExtension = SamplePackages.Instance.PackageWithoutRepoGitExtension.Value.FullName;
@@ -9,7 +11,7 @@ public class NuspecScrubbingTests
     private string _packageWithoutRepoUrl = SamplePackages.Instance.PackageWithoutRepoUrl.Value.FullName;
     private string _packageWithoutRepoCommit = SamplePackages.Instance.PackageWithoutRepoCommit.Value.FullName;
 
-    [Fact]
+    [TestMethod]
     public Task DoNotScrubGitExtensionOnRepoUrl()
     {
         VerifySettings settings = new();
@@ -19,7 +21,7 @@ public class NuspecScrubbingTests
         return VerifyFile(_packageWithRepoGitExtension, settings);
     }
 
-    [Fact]
+    [TestMethod]
     public Task AddGitExtensionToRepoUrl()
     {
         VerifySettings settings = new();
@@ -29,7 +31,7 @@ public class NuspecScrubbingTests
         return VerifyFile(_packageWithoutRepoGitExtension, settings);
     }
 
-    [Fact]
+    [TestMethod]
     public Task DoNotScrubNonHttpsRepoUrl()
     {
         VerifySettings settings = new();
@@ -39,7 +41,7 @@ public class NuspecScrubbingTests
         return VerifyFile(_packageWithoutRepoHttps, settings);
     }
 
-    [Fact]
+    [TestMethod]
     public Task DoNotScrubNonGitHubDomainRepoUrl()
     {
         VerifySettings settings = new();
@@ -49,7 +51,7 @@ public class NuspecScrubbingTests
         return VerifyFile(_packageWithoutRepoGitHubDomain, settings);
     }
 
-    [Fact]
+    [TestMethod]
     public Task SkipScrubbingForRepoWithNoCommit()
     {
         VerifySettings settings = new();
@@ -59,7 +61,7 @@ public class NuspecScrubbingTests
         return VerifyFile(_packageWithoutRepoCommit, settings);
     }
 
-    [Fact]
+    [TestMethod]
     public Task SkipScrubbingForRepoWithNoUrl()
     {
         VerifySettings settings = new();

--- a/Tests/Verify.Nupkg.Tests/PrebuiltArtifactsTestBase.cs
+++ b/Tests/Verify.Nupkg.Tests/PrebuiltArtifactsTestBase.cs
@@ -1,17 +1,13 @@
 ﻿using System.Reflection;
-using Xunit.Abstractions;
 
 namespace Verify.Nupkg.Tests;
 
 public abstract class PrebuiltArtifactsTestBase
 {
-    protected ITestOutputHelper Output { get; private set; }
     protected string PackagePath { get; private set; }
 
-    protected PrebuiltArtifactsTestBase(ITestOutputHelper output, string packageName)
+    protected PrebuiltArtifactsTestBase(string packageName)
     {
-        Output = output;
-
         PackagePath = GetLatestPackageVersion(packageName).FullName;
     }
 

--- a/Tests/Verify.Nupkg.Tests/SimplePackageTests.cs
+++ b/Tests/Verify.Nupkg.Tests/SimplePackageTests.cs
@@ -1,10 +1,12 @@
 namespace Verify.Nupkg.Tests;
 
-public class SimplePackageTests
+[TestClass]
+[UsesVerify]
+public partial class SimplePackageTests
 {
     private string _simplePackage = SamplePackages.Instance.SimplePackage.Value.FullName;
 
-    [Fact]
+    [TestMethod]
     public Task BasicTest()
     {
         VerifySettings settings = new();
@@ -14,7 +16,7 @@ public class SimplePackageTests
         return VerifyFile(_simplePackage, settings);
     }
 
-    [Fact]
+    [TestMethod]
     public Task CustomFileExclusionTest()
     {
         VerifySettings settings = new();
@@ -28,7 +30,7 @@ public class SimplePackageTests
         return VerifyFile(_simplePackage, settings);
     }
 
-    [Fact]
+    [TestMethod]
     public Task OnlyOptInScrubbersRun()
     {
         // In this test we intentionally _do not_ include these scrubbers:

--- a/Tests/Verify.Nupkg.Tests/Verify.Nupkg.Tests.csproj
+++ b/Tests/Verify.Nupkg.Tests/Verify.Nupkg.Tests.csproj
@@ -10,13 +10,11 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest" Version="3.3.1" />
     <PackageReference Include="MSBuild.ProjectCreation" Version="11.0.1" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.Extensions" Version="2.2.1" />
     <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" Version="20.0.15" />
-    <PackageReference Include="Verify.Xunit" Version="23.0.1" />
-    <PackageReference Include="xunit" Version="2.6.6" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6" PrivateAssets="all" />
+    <PackageReference Include="Verify.MSTest" Version="24.3.0-beta.2" /><!-- Testing MSTest source generator -->
     <PackageReference Include="coverlet.collector" Version="6.0.0" PrivateAssets="all" />
     <PackageReference Include="GetPackFromProject" Version="1.0.6" PrivateAssets="all" />
     <ProjectReference Include="..\..\Verify.Nupkg\Verify.Nupkg.csproj" AddPackageAsOutput="true" />

--- a/Tests/Verify.Nupkg.Tests/VerifyNupkgPackageTests.cs
+++ b/Tests/Verify.Nupkg.Tests/VerifyNupkgPackageTests.cs
@@ -1,14 +1,14 @@
-﻿using Xunit.Abstractions;
+﻿namespace Verify.Nupkg.Tests;
 
-namespace Verify.Nupkg.Tests;
-
-public class VerifyNupkgPackageTests : PrebuiltArtifactsTestBase
+[TestClass]
+[UsesVerify]
+public partial class VerifyNupkgPackageTests : PrebuiltArtifactsTestBase
 {
-    public VerifyNupkgPackageTests(ITestOutputHelper output) : base(output, "Verify.Nupkg")
+    public VerifyNupkgPackageTests() : base("Verify.Nupkg")
     {
     }
 
-    [Fact]
+    [TestMethod]
     public Task Baseline()
     {
         // This isn't a test of Verify.Nupkg project, but a baseline for the package itself.


### PR DESCRIPTION
Switch from xUnit to MSTest in order to validate new Verify.MSTest source generator. While making the change I also enabled test parallelization to save ~2 seconds per test run.