### PR TITLE
Scrub project name for GitHub repos

### DIFF
--- a/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.AddGitExtensionToRepoUrl/manifest.verified.nuspec
+++ b/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.AddGitExtensionToRepoUrl/manifest.verified.nuspec
@@ -5,7 +5,7 @@
     <authors>SimplePackage</authors>
     <readme>README.md</readme>
     <description>Package Description</description>
-    <repository type="git" url="https://github.com/MattKotsenas/Verify.Nupkg.git" commit="****************************************" />
+    <repository type="git" url="https://github.com/********/Verify.Nupkg.git" commit="****************************************" />
     <dependencies>
       <group targetFramework="net8.0" />
     </dependencies>

--- a/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.DoNotScrubGitExtensionOnRepoUrl/manifest.verified.nuspec
+++ b/Tests/Verify.Nupkg.Tests/NuspecScrubbingTests.DoNotScrubGitExtensionOnRepoUrl/manifest.verified.nuspec
@@ -4,7 +4,7 @@
     <version>********</version>
     <authors>PackageWithRepoGitExtension</authors>
     <description>Package Description</description>
-    <repository type="git" url="https://github.com/MattKotsenas/Verify.Nupkg.git" commit="****************************************" />
+    <repository type="git" url="https://github.com/********/Verify.Nupkg.git" commit="****************************************" />
     <dependencies>
       <group targetFramework="net8.0" />
     </dependencies>

--- a/Tests/Verify.Nupkg.Tests/SimplePackageTests.BasicTest/manifest.verified.nuspec
+++ b/Tests/Verify.Nupkg.Tests/SimplePackageTests.BasicTest/manifest.verified.nuspec
@@ -5,7 +5,7 @@
     <authors>SimplePackage</authors>
     <readme>README.md</readme>
     <description>Package Description</description>
-    <repository type="git" url="https://github.com/MattKotsenas/Verify.Nupkg.git" commit="****************************************" />
+    <repository type="git" url="https://github.com/********/Verify.Nupkg.git" commit="****************************************" />
     <dependencies>
       <group targetFramework="net8.0" />
     </dependencies>

--- a/Tests/Verify.Nupkg.Tests/SimplePackageTests.CustomFileExclusionTest/manifest.verified.nuspec
+++ b/Tests/Verify.Nupkg.Tests/SimplePackageTests.CustomFileExclusionTest/manifest.verified.nuspec
@@ -5,7 +5,7 @@
     <authors>SimplePackage</authors>
     <readme>README.md</readme>
     <description>Package Description</description>
-    <repository type="git" url="https://github.com/MattKotsenas/Verify.Nupkg.git" commit="****************************************" />
+    <repository type="git" url="https://github.com/********/Verify.Nupkg.git" commit="****************************************" />
     <dependencies>
       <group targetFramework="net8.0" />
     </dependencies>

--- a/Tests/Verify.Nupkg.Tests/SimplePackageTests.OnlyOptInScrubbersRun/manifest.verified.nuspec
+++ b/Tests/Verify.Nupkg.Tests/SimplePackageTests.OnlyOptInScrubbersRun/manifest.verified.nuspec
@@ -5,7 +5,7 @@
     <authors>SimplePackage</authors>
     <readme>README.md</readme>
     <description>Package Description</description>
-    <repository type="git" url="https://github.com/MattKotsenas/Verify.Nupkg.git" commit="****************************************" />
+    <repository type="git" url="https://github.com/********/Verify.Nupkg.git" commit="****************************************" />
     <dependencies>
       <group targetFramework="net8.0" />
     </dependencies>

--- a/Tests/Verify.Nupkg.Tests/VerifyNupkgPackageTests.Baseline/manifest.verified.nuspec
+++ b/Tests/Verify.Nupkg.Tests/VerifyNupkgPackageTests.Baseline/manifest.verified.nuspec
@@ -11,7 +11,7 @@
     <description>Extends Verify (https://github.com/VerifyTests/Verify) to allow verification of NuGet .nupkg files.</description>
     <copyright>Copyright 2024. All rights reserved</copyright>
     <tags>NuGet, Nupkg, Verify</tags>
-    <repository type="git" url="https://github.com/MattKotsenas/Verify.Nupkg.git" commit="****************************************" />
+    <repository type="git" url="https://github.com/********/Verify.Nupkg.git" commit="****************************************" />
     <dependencies>
       <group targetFramework=".NETFramework4.7.2">
         <dependency id="Verify" version="23.0.1" exclude="Build,Analyzers" />

--- a/Verify.Nupkg/RepositoryUrlScrubber.cs
+++ b/Verify.Nupkg/RepositoryUrlScrubber.cs
@@ -1,9 +1,13 @@
-﻿using System.Xml.Linq;
+﻿using System.Text.RegularExpressions;
+using System.Xml.Linq;
 
 namespace VerifyTests;
 
 internal class RepositoryUrlScrubber : NuspecScrubberBase
 {
+    private static readonly Regex ProjectRegex = new("^/([^/]*)");
+    private static readonly string ProjectNameReplacement = "/********";
+
     protected override void Scrub(XDocument document)
     {
         XElement[] repositoryElements = document.DescendantsAnyNS("repository").ToArray();
@@ -28,8 +32,11 @@ internal class RepositoryUrlScrubber : NuspecScrubberBase
             if (!url.Path.EndsWith(".git"))
             {
                 url.Path += ".git";
-                urlAttribute.SetValue(url.Uri.ToString());
             }
+
+            url.Path = ProjectRegex.Replace(url.Path, ProjectNameReplacement);
+
+            urlAttribute.SetValue(url.Uri.ToString());
         }
     }
 }

--- a/Verify.Nupkg/VerifySettingsScrubExtensions.cs
+++ b/Verify.Nupkg/VerifySettingsScrubExtensions.cs
@@ -177,8 +177,8 @@ public static class VerifySettingsScrubExtensions
     /// The <see cref="VerifierSettings"/> to modify.
     /// </param>
     /// <remarks>
-    /// GitHub repository URLs can be optionally have a `.git` suffix. This method normalizes the URL to always end with .git
-    /// to reduce the noise in the diff.
+    /// GitHub repository URLs can be optionally have a `.git` suffix. This method normalizes the URL to always end with .git.
+    /// This method also normalizes GitHub urls to replace the project name so that forks do not cause diffs.
     /// </remarks>
     /// <returns>The <see cref="VerifySettings"/> for chaining.</returns>
     public static VerifySettings ScrubNuspecRepositoryUrl(this VerifySettings settings)


### PR DESCRIPTION
Forks of GitHub projects run into a scrubbing problem because the repo url contains the name of the project.

Scrub the name of the project when the repo URL is GitHub.