### PR TITLE
Drop net6.0 and net7.0, add net9.0

### DIFF
--- a/Tests/Verify.Nupkg.Tests/Verify.Nupkg.Tests.csproj
+++ b/Tests/Verify.Nupkg.Tests/Verify.Nupkg.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <!-- Limit .NET Framework tests to Windows build / test machines -->
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">net472</TargetFrameworks>
-    <TargetFrameworks>$(TargetFrameworks);net8.0</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks);net8.0;net9.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>

--- a/Tests/Verify.Nupkg.Tests/VerifyNupkgPackageTests.Baseline/contents.verified.txt
+++ b/Tests/Verify.Nupkg.Tests/VerifyNupkgPackageTests.Baseline/contents.verified.txt
@@ -6,12 +6,9 @@
 |   |-- net472
 |   |   |-- Verify.Nupkg.dll
 |   |   |-- Verify.Nupkg.xml
-|   |-- net6.0
-|   |   |-- Verify.Nupkg.dll
-|   |   |-- Verify.Nupkg.xml
-|   |-- net7.0
-|   |   |-- Verify.Nupkg.dll
-|   |   |-- Verify.Nupkg.xml
 |   |-- net8.0
+|   |   |-- Verify.Nupkg.dll
+|   |   |-- Verify.Nupkg.xml
+|   |-- net9.0
 |   |   |-- Verify.Nupkg.dll
 |   |   |-- Verify.Nupkg.xml

--- a/Tests/Verify.Nupkg.Tests/VerifyNupkgPackageTests.Baseline/manifest.verified.nuspec
+++ b/Tests/Verify.Nupkg.Tests/VerifyNupkgPackageTests.Baseline/manifest.verified.nuspec
@@ -16,13 +16,10 @@
       <group targetFramework=".NETFramework4.7.2">
         <dependency id="Verify" version="23.0.1" exclude="Build,Analyzers" />
       </group>
-      <group targetFramework="net6.0">
-        <dependency id="Verify" version="23.0.1" exclude="Build,Analyzers" />
-      </group>
-      <group targetFramework="net7.0">
-        <dependency id="Verify" version="23.0.1" exclude="Build,Analyzers" />
-      </group>
       <group targetFramework="net8.0">
+        <dependency id="Verify" version="23.0.1" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net9.0">
         <dependency id="Verify" version="23.0.1" exclude="Build,Analyzers" />
       </group>
     </dependencies>

--- a/Verify.Nupkg/Verify.Nupkg.csproj
+++ b/Verify.Nupkg/Verify.Nupkg.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0;net9.0</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <GenerateDocumentationFile>True</GenerateDocumentationFile>
     <PackageId>Verify.Nupkg</PackageId>


### PR DESCRIPTION
Remove support for net6.0 and net7.0, and add support for net9.0.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MattKotsenas/Verify.Nupkg/pull/33?shareId=4b8ab72b-1d72-44d0-b557-733c624288d6).